### PR TITLE
Lamp: emissive binding + temporary light offset

### DIFF
--- a/docs/assets/street-lamp-scratchpad.md
+++ b/docs/assets/street-lamp-scratchpad.md
@@ -88,3 +88,15 @@
 - Hedwig Draco Export preset rebuilt (glb, selected objects, tangents, Draco level 6) and reused for final export.
 - Overwrote `public/assets/models/props/SM_StreetLamp_Simple.glb`; runtime test pending but emissive slider ready (0.1 off → 1.5 on).
 - To-do: capture on/off viewport renders during next Blender session.
+- 🔄 Runtime follow-up: bind Dev Room GUI lamp slider directly to material emissive intensity (0.1 ↔ 1.5) and re-test point-light offset once new GLB lands.
+
+## Upcoming Blender Fix – Internal Light Blocker (planned 2025-10-07)
+- **Problem:** With the point light positioned inside the lantern, the outer roof still catches harsh highlights; current blocker panes are single surfaces so light reaches the same triangles that form the roof shell.
+- **Goal:** Add a shallow sealed “cap” inside the lantern so the bulb can sit at physical height (~0.45) without lighting the exterior metal.
+- **Steps to perform in Blender:**
+  1. Duplicate the blocker geometry and extrude it upward to form a thin hexagonal prism that closes the top (sides + lid). Aim for 1–2 cm thickness so the light has material to hit.
+  2. Ensure the new blocker surfaces have inward-facing normals. Apply transforms (`Ctrl+A`) and recalc normals if anything flips.
+  3. Assign the roof metal material to the blocker; verify the emission mask stays untouched so glass remains the only emissive region.
+  4. Inspect for gaps between blocker and roof; close any seams so the point light cannot peek through.
+  5. Re-export `SM_StreetLamp_Simple.glb` with the Hedwig Draco preset once satisfied and log results below.
+- **Post-export test checklist:** In the Dev Room set lamp light height to 0.45, intensity 35; confirm roof stays dark while glass + emissive glow remain convincing.

--- a/docs/assets/street-lamp-scratchpad.md
+++ b/docs/assets/street-lamp-scratchpad.md
@@ -91,6 +91,7 @@
 - 🔄 Runtime follow-up: bind Dev Room GUI lamp slider directly to material emissive intensity (0.1 ↔ 1.5) and re-test point-light offset once new GLB lands.
 
 ## Upcoming Blender Fix – Internal Light Blocker (planned 2025-10-07)
+- **Tracking:** GitHub issue #10.
 - **Problem:** With the point light positioned inside the lantern, the outer roof still catches harsh highlights; current blocker panes are single surfaces so light reaches the same triangles that form the roof shell.
 - **Goal:** Add a shallow sealed “cap” inside the lantern so the bulb can sit at physical height (~0.45) without lighting the exterior metal.
 - **Steps to perform in Blender:**
@@ -100,3 +101,6 @@
   4. Inspect for gaps between blocker and roof; close any seams so the point light cannot peek through.
   5. Re-export `SM_StreetLamp_Simple.glb` with the Hedwig Draco preset once satisfied and log results below.
 - **Post-export test checklist:** In the Dev Room set lamp light height to 0.45, intensity 35; confirm roof stays dark while glass + emissive glow remain convincing.
+
+### Temporary Engine Workaround (2025-10-09)
+- Point light height offset is clamped to 0.22 in the Dev Room so the bulb sits above the roof and no longer blows out the metal. This keeps the lamp readable but introduces a mild self-shadow; resolve once issue #10 lands.

--- a/docs/assets/street-lamp-session-notes.md
+++ b/docs/assets/street-lamp-session-notes.md
@@ -39,3 +39,4 @@
 - 📸 TODO: capture Blender viewport renders (emissive off/on) next session for docs.
 - 🔄 Runtime follow-up: bind Dev Room GUI lamp slider directly to material emissive intensity (0.1 ↔ 1.5) and re-test point-light offset once new GLB lands.
 - 🛠️ New TODO (2025-10-07): create a sealed interior light blocker (thin hexagonal prism) so internal point lights no longer brighten the outer roof; re-export GLB afterwards.
+- 📉 Interim workaround (2025-10-09): Dev Room keeps the lamp light offset at 0.22 (above the roof) to avoid the harsh highlight; revisit when issue #10 is closed.

--- a/docs/assets/street-lamp-session-notes.md
+++ b/docs/assets/street-lamp-session-notes.md
@@ -38,3 +38,4 @@
 - ⭐ Rebuilt Hedwig Draco export preset and re-exported `public/assets/models/props/SM_StreetLamp_Simple.glb` with updated geometry.
 - 📸 TODO: capture Blender viewport renders (emissive off/on) next session for docs.
 - 🔄 Runtime follow-up: bind Dev Room GUI lamp slider directly to material emissive intensity (0.1 ↔ 1.5) and re-test point-light offset once new GLB lands.
+- 🛠️ New TODO (2025-10-07): create a sealed interior light blocker (thin hexagonal prism) so internal point lights no longer brighten the outer roof; re-export GLB afterwards.

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -11,6 +11,7 @@
 - **Loading screen polish**: design a thematic preloader page with art + “Begin” button to distract from large asset loads.
 - **Interactive intro overlay**: show controls, goals, and “press ESC to unlock mouse” guidance while the scene finishes initializing; tap-to-start drops the player into the world.
 - **In-game HUD shell**: add lightweight navigation elements (settings toggle, lil-gui visibility button, etc.) so the game window feels intentional.
+- **Restore lamp light inside lantern**: move the Dev Room lamp light back inside once the internal blocker is modeled (see issue #10).
 
 ## Urgent & Not Important (Delegate / Quick Wins)
 - _None logged yet_

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -18,3 +18,4 @@
 ## Not Urgent & Not Important (Consider Later / Maybe Never)
 - **Scripted moon path demo**: animate the moon position over time to showcase lighting/shadow changes for friends and family.
 - **esbuild dev-server advisory**: npm audit flags an esbuild dev-server vulnerability; low concern for local-only Vite usage but keep on radar for future dependency bumps.
+- **Individual lamp flicker sequences**: once lamps populate the cemetery, trigger random flicker/blackout patterns per lamp (see issue #9 for architecture sketch).

--- a/src/assets/DevRoom.js
+++ b/src/assets/DevRoom.js
@@ -5,12 +5,16 @@
 // before building the full cemetery layout.
 
 import * as THREE from 'three';
+import { DEFAULTS } from '../config/Constants.js';
 const { PointLight, PointLightHelper, Box3, Vector3 } = THREE;
 import { loadStreetLampInstance } from './Assets.js';
 
 const bounds = new Box3();
 const center = new Vector3();
 const DEFAULT_LAMP_LIGHT_OFFSET = 0.25; // Keep bulb tucked inside lantern
+const MIN_EMISSIVE_INTENSITY = 0.1; // Matches Blender's "lamp off" baseline
+const DEFAULT_LIGHT_INTENSITY = DEFAULTS.devRoomLampLightIntensity; // 35
+const DEFAULT_EMISSIVE_INTENSITY = 1.5; // Lamp glass glow for "on"
 
 /**
  * Create the Dev Room container and start loading the lamp asset.
@@ -35,7 +39,39 @@ export function createDevRoom({ scene, world, environment }) {
     lampLight,
     lampLightHelper: null,
     lampLightOffset: DEFAULT_LAMP_LIGHT_OFFSET,
+    lampMaterials: [],
+    targetEmissiveIntensity: computeEmissiveFromLight(DEFAULT_LIGHT_INTENSITY),
   };
+
+  function computeEmissiveFromLight(lightIntensity) {
+    if (DEFAULT_LIGHT_INTENSITY <= 0) {
+      return MIN_EMISSIVE_INTENSITY;
+    }
+
+    const safeIntensity = Math.max(0, lightIntensity);
+    const ratio = safeIntensity / DEFAULT_LIGHT_INTENSITY;
+    const emissive = MIN_EMISSIVE_INTENSITY + (DEFAULT_EMISSIVE_INTENSITY - MIN_EMISSIVE_INTENSITY) * ratio;
+    return Math.max(MIN_EMISSIVE_INTENSITY, emissive);
+  }
+
+  function applyEmissiveToMaterials(intensity) {
+    state.targetEmissiveIntensity = intensity;
+    if (!state.lampMaterials.length) {
+      return;
+    }
+
+    state.lampMaterials.forEach((material) => {
+      if ('emissiveIntensity' in material) {
+        material.emissiveIntensity = intensity;
+      }
+    });
+  }
+
+  function updateLampEmissiveFromLight(lightIntensity, isVisible) {
+    const baseIntensity = isVisible ? lightIntensity : 0;
+    const emissive = computeEmissiveFromLight(baseIntensity);
+    applyEmissiveToMaterials(emissive);
+  }
 
   const positionLampLight = () => {
     if (!state.lamp) return;
@@ -53,13 +89,26 @@ export function createDevRoom({ scene, world, environment }) {
       const { scene: lampScene } = await loadStreetLampInstance();
       lampScene.name = 'DevRoom_StreetLamp';
 
+      const lampMaterials = new Set();
+
       // Ensure the prop participates in lighting.
       lampScene.traverse((child) => {
         if (child.isMesh) {
           child.castShadow = true;
           child.receiveShadow = true;
+
+          if (child.material) {
+            const materials = Array.isArray(child.material) ? child.material : [child.material];
+            materials.forEach((mat) => {
+              if (mat && typeof mat === 'object' && 'emissiveIntensity' in mat) {
+                lampMaterials.add(mat);
+              }
+            });
+          }
         }
       });
+
+      state.lampMaterials = Array.from(lampMaterials);
 
       // Drop it at the origin on the ground plane by default.
       lampScene.position.set(0, 0, 0);
@@ -69,6 +118,8 @@ export function createDevRoom({ scene, world, environment }) {
       if (environment && typeof environment.registerAsset === 'function') {
         environment.registerAsset(lampScene);
       }
+
+      applyEmissiveToMaterials(state.targetEmissiveIntensity);
 
       positionLampLight();
 
@@ -114,6 +165,13 @@ export function createDevRoom({ scene, world, environment }) {
         state.lampLightOffset = heightOffset;
       }
       positionLampLight();
+      updateLampEmissiveFromLight(lampLight.intensity, lampLight.visible);
+    },
+    setLampEmissiveIntensity: (intensity) => {
+      applyEmissiveToMaterials(Math.max(MIN_EMISSIVE_INTENSITY, intensity));
+    },
+    setLampEmissiveFromLight: (lightIntensity, isVisible = lampLight.visible) => {
+      updateLampEmissiveFromLight(lightIntensity, isVisible);
     },
     setLampLightHelperVisible: (visible) => {
       if (state.lampLightHelper) {
@@ -130,6 +188,7 @@ export function createDevRoom({ scene, world, environment }) {
       root.clear();
       scene.remove(root);
       state.lamp = null;
+      state.lampMaterials = [];
     },
   };
 }

--- a/src/assets/DevRoom.js
+++ b/src/assets/DevRoom.js
@@ -11,7 +11,8 @@ import { loadStreetLampInstance } from './Assets.js';
 
 const bounds = new Box3();
 const center = new Vector3();
-const DEFAULT_LAMP_LIGHT_OFFSET = 0.25; // Keep bulb tucked inside lantern
+// TODO(#10): Drop the offset back inside the lantern once we add a sealed blocker in Blender.
+const DEFAULT_LAMP_LIGHT_OFFSET = 0.22; // Quick fix: keep bulb slightly above roof for now
 const MIN_EMISSIVE_INTENSITY = 0.1; // Matches Blender's "lamp off" baseline
 const DEFAULT_LIGHT_INTENSITY = DEFAULTS.devRoomLampLightIntensity; // 35
 const DEFAULT_EMISSIVE_INTENSITY = 1.5; // Lamp glass glow for "on"

--- a/src/config/Constants.js
+++ b/src/config/Constants.js
@@ -110,7 +110,7 @@ export const DEFAULTS = {
   devRoomLampLightDecay: 2.2,
   devRoomLampLightColor: '#fff2c0',
   devRoomLampLightHelperVisible: false,
-  devRoomLampLightOffset: 0.25,
+  devRoomLampLightOffset: 0.22,
 };
 
 // HDRI options available


### PR DESCRIPTION
## Summary
- teach Dev Room to sync lamp emissive intensity with the point light
- pin the lamp light height to 0.22 for now so the roof highlight goes away (see #10)
- document the workaround in the lamp scratchpad/session notes and backlog

## Testing
- npm run build
